### PR TITLE
Add simple plugin system

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,9 @@
 `BlogDown <https://github.com/brantyoung/blogdown/>`_ is a simple static blog generator,
-folked from `Armin Ronacher <http://lucumr.pocoo.org/>`_'s `rstblog <https://github.com/mitsuhiko/rstblog/>`_.
+forked from `Armin Ronacher <http://lucumr.pocoo.org/>`_'s `rstblog <https://github.com/mitsuhiko/rstblog/>`_.
 
 BlogDown support both reStructuredText and Markdown markup.
 
+BlogDown can be extended by plugins. The search path is configured by the
+config variable ``plugin_folders`` and defaults to ``_plugins``. Plugins can
+also be installed using the ``blogdown.plugin`` entrypoint. For examples,
+see the files in ``blogdown/modules``.

--- a/blogdown/builder.py
+++ b/blogdown/builder.py
@@ -205,7 +205,7 @@ class Builder(object):
 
         # The order is chosen on purpose to allow overriding:
         # local configuration > 3rdparty entrypoints > blogdown default
-        plugin_loader = plugin.MultiLoader(
+        plugin_loader = plugin.ChainLoader(
             [plugin.PathLoader(path)
              for path in self.config.get('plugin_folders', ['_plugins'])] +
             [plugin.EntryPointLoader('blogdown.plugin'),

--- a/blogdown/modules/__init__.py
+++ b/blogdown/modules/__init__.py
@@ -8,17 +8,3 @@
     :copyright: (c) 2010 by Armin Ronacher.
     :license: BSD, see LICENSE for more details.
 """
-
-
-def add_module_path(folder):
-    """Adds a new search path to the list of search paths."""
-    import os
-    __path__.append(os.path.abspath(folder))
-
-
-def find_module(name):
-    """Returns the module by the given name or raises an ImportError."""
-    import sys
-    full_name = 'blogdown.modules.' + name
-    __import__(full_name)
-    return sys.modules[full_name]

--- a/blogdown/plugin.py
+++ b/blogdown/plugin.py
@@ -18,7 +18,8 @@ from runpy import run_path
 __all__ = [
     'EntryPointLoader',
     'PathLoader',
-    'MultiLoader',
+    'PackageLoader',
+    'ChainLoader',
 ]
 
 
@@ -76,7 +77,7 @@ class PackageLoader:
                 .format(module))
 
 
-class MultiLoader:
+class ChainLoader:
 
     """Load plugins from all of the sub-loaders."""
 

--- a/blogdown/plugin.py
+++ b/blogdown/plugin.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""
+    blogdown.plugin
+    ~~~~~~~~~~~~~~~
+
+    Utilities for a simple plugin system.
+
+    :copyright: (c) 2015 by Thomas Gläßle
+    :license: BSD, see LICENSE for more details.
+"""
+
+import os
+from importlib import import_module
+from pkg_resources import iter_entry_points
+from runpy import run_path
+
+
+__all__ = [
+    'EntryPointLoader',
+    'PathLoader',
+    'MultiLoader',
+]
+
+
+class EntryPointLoader:
+
+    """Load plugins from specified entrypoint group."""
+
+    def __init__(self, ep_group):
+        self.ep_group = ep_group
+
+    def __call__(self, name):
+        for ep in iter_entry_points(self.ep_group, name):
+            yield ep.load()
+
+
+class PathLoader:
+
+    """Load plugins from specified folder."""
+
+    def __init__(self, search_path):
+        self.search_path = os.path.abspath(search_path)
+
+    def __call__(self, name):
+        module_path = os.path.join(self.search_path, name + '.py')
+        if not os.path.isfile(module_path):
+            return
+        module = run_path(module_path)
+        try:
+            yield module['setup']
+        except KeyError:
+            raise AttributeError(
+                "Module at {0!r} can't be used as a plugin, "
+                "since it has no 'setup' function."
+                .format(module_path))
+
+
+class PackageLoader:
+
+    """Load plugins from specified package."""
+
+    def __init__(self, package_name):
+        self.package_name = package_name
+
+    def __call__(self, module_name):
+        try:
+            module = import_module(self.package_name + '.' + module_name)
+        except ImportError:
+            return
+        try:
+            yield module.setup
+        except AttributeError:
+            raise AttributeError(
+                "{0!r} can't be used as a plugin, "
+                "since it has no 'setup' function."
+                .format(module))
+
+
+class MultiLoader:
+
+    """Load plugins from all of the sub-loaders."""
+
+    def __init__(self, loaders):
+        self.loaders = loaders
+
+    def __call__(self, name):
+        for loader in self.loaders:
+            for plugin in loader(name):
+                yield plugin


### PR DESCRIPTION
I provided three basic mechanisms:

- load files in '_plugins' folder using runpy — for local plugins
- load plugin from 'blogdown.plugin' entrypoint — for installed plugins
- load modules from 'blogdown.modules' package — for builtin plugins

These are tried in order and the first discovered plugin for the specified
name is used.

The last two are redundant and could be used as replacements for each other:

- all the modules in blogdown.modules could be added as entrypoints
- the blogdown.modules could be made a namespace package allowing to add
  further modules by installing further modules into that namespace

I implemented all three anyway, since this appears to me being cleaner and
wasn't much work. I can of course change it if you'd like it better
differently.

Resolves #3.