### PR TITLE
Fix: markdown class for pygments

### DIFF
--- a/blogdown/programs.py
+++ b/blogdown/programs.py
@@ -210,7 +210,7 @@ class MDProgram(TemplatedProgram):
                 'abbr',
                 'meta',
                 'headerid',
-                'codehilite(pygments_style=tango, css_class=syntax, guess_lang=True)'
+                'codehilite(pygments_style=tango, css_class=hll, guess_lang=True)'
             ]
         )
 


### PR DESCRIPTION
When I used your py3 version to generate blog from markdown, I had "syntax" class for the code in HTML and "hll" in CSS.

This is a trival fix.

Btw. thanks for blogdown - I like the simplicity of Armin's blog engine but am not RST-friendly ;-)