### PR TITLE
Fix: disqus plugin rendered as bytes in Python3

### DIFF
--- a/blogdown/modules/disqus.py
+++ b/blogdown/modules/disqus.py
@@ -4,12 +4,12 @@
     ~~~~~~~~~~~~~~~~~~~~~~~
 
     Implements disqus element if asked for.
-    
+
     To use this, include ``disqus`` in the list of modules in your ``config.yml`` file,
-    and add a configuration variable to match your settings : ``disqus.shortname`` 
-    
+    and add a configuration variable to match your settings : ``disqus.shortname``
+
     To set developer mode on the site, set ``disqus.developer=1`` in your ``config.yml`` file.
-    
+
     To prevent comments on a particular page, set ``disqus = no`` in the page's YAML preamble.
 
     :copyright: (c) 2012 by Martin Andrews.
@@ -26,13 +26,13 @@ def get_disqus(context):
     var_developer=''
     if context['builder'].config.root_get('modules.disqus.developer', False):
         var_developer='var disqus_developer = 1;'
-    
+
     disqus_txt="""
 <div id="disqus_thread"></div>
 <script type="text/javascript">
     var disqus_shortname = '%s'; // required: replace example with your forum shortname
     %s
-    
+
     /* * * DON'T EDIT BELOW THIS LINE * * */
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
@@ -46,8 +46,8 @@ def get_disqus(context):
 
     if not context['config'].get('disqus', True):
         disqus_txt='' # "<h1>DISQUS DEFEATED</h1>"
-        
-    return jinja2.Markup(disqus_txt.encode('utf-8'))
+
+    return jinja2.Markup(disqus_txt)
 
 
 def setup(builder):


### PR DESCRIPTION
I remove the "encode" because otherwise the result of get_disqus function was a bytes object that Jinja rendered using "repr" (i.e. useless), not as a string. After I did that, disqus started working for me.

Hopefully it is safe so.
